### PR TITLE
JpaAuditing activated

### DIFF
--- a/src/main/java/org/example/mega_crew/domain/user/entity/User.java
+++ b/src/main/java/org/example/mega_crew/domain/user/entity/User.java
@@ -75,7 +75,7 @@ public class User extends BaseEntity implements UserDetails {
   }
 
   @Override
-  public boolean isAccountNonExpired() {
+  public boolean isAccountNonExpired() { // 검증 logic 추후 구현하기
     return true;
   }
 
@@ -88,4 +88,5 @@ public class User extends BaseEntity implements UserDetails {
   public boolean isEnabled() {
     return true;
   }
+
 }

--- a/src/main/java/org/example/mega_crew/global/common/BaseEntity.java
+++ b/src/main/java/org/example/mega_crew/global/common/BaseEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,8 +16,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-@Getter
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
@@ -24,4 +24,12 @@ public class BaseEntity {
 
     @LastModifiedDate
     private LocalDateTime modifiedDate;
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return modifiedDate;
+    }
 }

--- a/src/main/java/org/example/mega_crew/global/security/SecurityConfig.java
+++ b/src/main/java/org/example/mega_crew/global/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.example.mega_crew.global.security.oauth2.OAuth2AuthenticationSuccessH
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,6 +26,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@EnableJpaAuditing // BaseEntity의 createdDate, modifiedDate 자동 기록을 위한 annotation
 @RequiredArgsConstructor
 public class SecurityConfig {
 


### PR DESCRIPTION
BaseEntity의 createdDate, modifiedDate가 제대로 기록되지 않는 문제를 해결하기 위해
JpaAuditing을 활성화하였습니다.

간단한 테스트를 통해 문제가 해결되었음을 검증하였습니다.